### PR TITLE
Restrict access to only authorized_users

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,25 @@ options = {
 Precious::App.set(:omnigollum, options)
 ```
 
+### Access control
+
+By default, any authenticated user will be able to access the protected routes. Restrict this by setting the `authorized_users` option.
+
+`authorized_users` accepts an array of emails. Users must authenticate with one of these authorized emails in order to be allowed access.
+
+```ruby
+options[:authorized_users] = ["john@fourthcoffee.com", "susan@fourthcoffee.com", "james@fourthcoffee.com"]
+```
+
+Instead of setting these directly, you can use an [env var](http://www.12factor.net/config), maybe like this:
+
+```ruby
+# in .env, or other
+# OMNIGOLLUM_AUTHORIZED_USERS=john@fourthcoffee.com,susan@fourthcoffee.com,james@fourthcoffee.com
+
+options[:authorized_users] = ENV["OMNIGOLLUM_AUTHORIZED_USERS"].split(",")
+```
+
 ### Register omnigollum extension with sinatra
 ```ruby
 Precious::App.register Omnigollum::Sinatra


### PR DESCRIPTION
This adds a new configuration option `authorized_users` that should contain an array of emails. After authentication via OmniAuth, the user's email is compared against this list and an exception is raised if their email is not included. Leaving `authorized_users` blank or setting it to an empty array (the default) disables this functionality.

I liked that Omnigollum added authentication to Gollum, but I was disappointed to find that there apparently was no option to only allow certain users to have access. This change adds that.
