### PR TITLE
Fix TypeError handling a nil param

### DIFF
--- a/lib/omnigollum.rb
+++ b/lib/omnigollum.rb
@@ -234,7 +234,7 @@ module Omnigollum
       app.before options[:route_prefix] + '/auth/failure' do
         user_deauth
         @title    = 'Authentication failed'
-        @subtext = 'Provider did not validate your credentials (' + params[:message] + ') - please retry or choose another login service'
+        @subtext = "Provider did not validate your credentials (#{params[:message]}) - please retry or choose another login service"
         @auth_params = "?origin=#{CGI.escape(request.env['omniauth.origin'])}" unless request.env['omniauth.origin'].nil?
         show_login
       end


### PR DESCRIPTION
This fixes this error that my users are getting:
TypeError - can't convert nil into String:
shared/bundle/ruby/1.9.1/bundler/gems/omnigollum-f7eca9daea6d/lib/omnigollum.rb:237:in `+'
