### PR TITLE
Mustache 0.99.5 is now released, so the section for that can be removed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,17 +83,8 @@ Precious::App.register Omnigollum::Sinatra
 
 ## Required patches
 
-### mustache
-
-https://github.com/defunkt/mustache
-
-Must be at v0.99.5 (currently unreleased), replace the gem version with 6c4e12d58844d99909df or
-the current HEAD.
-
-Feel free to complain loudly that the maintainer should roll a new gem.
-
 ### Gollum
-You can also (optionally) apply the patches here, to get a neat little auth
+You can (optionally) apply the patches here, to get a neat little auth
 status widget in the top right corner of the page https://github.com/arr2036/gollum/commit/32de2cad920ccc6e955b8e19f6e23c2b3b4c8964
 
 


### PR DESCRIPTION
No need to use HEAD from Mustache any longer.
