### PR TITLE
Fixes redirect loop bug by adding error template

### DIFF
--- a/lib/omnigollum.rb
+++ b/lib/omnigollum.rb
@@ -97,6 +97,13 @@ module Omnigollum
       end
     end
 
+    def show_error
+      options = settings.send(:omnigollum)
+      auth_config
+      require options[:path_views] + '/error'
+      halt mustache Omnigollum::Views::Error
+    end
+
     def commit_message
       if user_authed?
         user = get_user
@@ -239,7 +246,7 @@ module Omnigollum
         @title    = 'Authentication failed'
         @subtext = "Provider did not validate your credentials (#{params[:message]}) - please retry or choose another login service"
         @auth_params = "?origin=#{CGI.escape(request.env['omniauth.origin'])}" unless request.env['omniauth.origin'].nil?
-        show_login
+        show_error
       end
 
       app.before options[:route_prefix] + '/auth/:name/callback' do
@@ -253,7 +260,7 @@ module Omnigollum
               @title   = 'Authorization failed'
               @subtext = 'User was not found in the authorized users list'
               @auth_params = "?origin=#{CGI.escape(request.env['omniauth.origin'])}" unless request.env['omniauth.origin'].nil?
-              show_login
+              show_error
             end
 
             session[:omniauth_user] = user
@@ -269,13 +276,13 @@ module Omnigollum
             @title   = 'Authentication failed'
             @subtext = 'Omniauth experienced an error processing your request'
             @auth_params = "?origin=#{CGI.escape(request.env['omniauth.origin'])}" unless request.env['omniauth.origin'].nil?
-            show_login
+            show_error
           end
         rescue StandardError => fail_reason
           @title   = 'Authentication failed'
           @subtext = fail_reason
           @auth_params = "?origin=#{CGI.escape(request.env['omniauth.origin'])}" unless request.env['omniauth.origin'].nil?
-          show_login
+          show_error
         end
       end
 

--- a/templates/Error.mustache
+++ b/templates/Error.mustache
@@ -1,0 +1,7 @@
+<div id="wiki-wrapper" class="markdown-body">
+<h2>{{title}}</h2>
+<div id="login" class="login_form"> 
+  <h3>{{subtext}}</h3>
+  <a href="{{loginurl}}">Try again</a>
+</div>
+</div>

--- a/views/error.rb
+++ b/views/error.rb
@@ -1,0 +1,20 @@
+module Omnigollum
+  module Views
+    class Error < Mustache
+      self.template_path = File.expand_path("../../templates", __FILE__)
+      self.template_name = 'Error'
+      
+      def title
+        @title
+      end
+      
+      def subtext
+        @subtext
+      end
+
+      def loginurl
+        @auth[:route_prefix] + 'login' + (defined?(@auth_params) ? @auth_params : '')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Please review and see if this is how you meant. Simply added an error template which is used instead of the login template if an error occurs. `show_login` is only used initially and by the `/login` route, and the error template contains a link "Try again" which redirects to login (keeping origin if found on `auth_params`).
