### PR TITLE
Regex access control

### DIFF
--- a/lib/omnigollum.rb
+++ b/lib/omnigollum.rb
@@ -256,9 +256,17 @@ module Omnigollum
           if !request.env['omniauth.auth'].nil?
             user = Omnigollum::Models::OmniauthUser.new(request.env['omniauth.auth'], options)
 
+            case (authorized_users = options[:authorized_users])
+            when Regexp
+              user_authorized = (user.email =~ authorized_users)
+            when Array
+              user_authorized = authorized_users.include?(user.email) || authorized_users.include?(user.nickname)
+            else
+              user_authorized = true
+            end
+
             # Check authorized users
-            if !options[:authorized_users].empty? && !options[:authorized_users].include?(user.email) &&
-               !options[:authorized_users].include?(user.nickname)
+            if !user_authorized
               @title   = 'Authorization failed'
               @subtext = 'User was not found in the authorized users list'
               @auth_params = "?origin=#{CGI.escape(request.env['omniauth.origin'])}" unless request.env['omniauth.origin'].nil?


### PR DESCRIPTION
Hey,

I was using this gem for my company, and I thought it would be useful to enter a regex for options[:authorized_users], to save the user inputting all the emails allowed access to a wiki.

If options[:authorized_users] is an array, the conditions of access are as before. But if it's a Regex, there has to be a match. Fairly simple stuff.
