### PR TITLE
Fix issue where base path was ignored

### DIFF
--- a/lib/omnigollum.rb
+++ b/lib/omnigollum.rb
@@ -88,7 +88,7 @@ module Omnigollum
           origin = '/'
         end
 
-        redirect options[:route_prefix] + '/auth/' + options[:provider_names].first.to_s + "?origin=" +
+        redirect (request.script_name || '') + options[:route_prefix] + '/auth/' + options[:provider_names].first.to_s + "?origin=" +
            CGI.escape(origin)
       else
          auth_config


### PR DESCRIPTION
Fixes #9 

- Fixes issue where custom base path of `/wiki` would be ignored by omniauth
- Uses fix suggested by @aldanor